### PR TITLE
simplified the hashtable module. now uses int32_t:int32_t for the key:value

### DIFF
--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -4,21 +4,21 @@
     LeafWSI - a C based, cross-platform, whitespace lang interpretter.
     Copyright (C) 2023  Sage I. Hendricks
 
-    LeafWSI is free software: you can redistribute it and/or modify 
-    it under the terms of the GNU General Public License as published by 
-    the Free Software Foundation, either version 3 of the License, or 
+    LeafWSI is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    LeafWSI is distributed in the hope that it will be useful, 
-    but WITHOUT ANY WARRANTY; without even the implied warranty of 
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+    LeafWSI is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License 
-    along with LeafWSI. If not, see <https://www.gnu.org/licenses/>. 
+    You should have received a copy of the GNU General Public License
+    along with LeafWSI. If not, see <https://www.gnu.org/licenses/>.
 */
 
-/* 
+/*
 Contact Information:
     Email   sage.codes@email.com
     Github  sage-etcher
@@ -48,11 +48,8 @@ Contact Information:
 /* type definitions */
 typedef struct
 {
-    char *key;
-    uintmax_t key_size;
-
-    void *value;
-    size_t value_size;
+    int32_t key;
+    int32_t value;
 } keyValuePair;
 
 typedef struct
@@ -64,17 +61,17 @@ typedef struct
 
 
 /* function prototypes */
-keyValuePair *new_keyValuePair (char *key, void *value, size_t value_size);
+keyValuePair *new_keyValuePair (int32_t key, int32_t value);
 void free_keyValuePair (keyValuePair *pair);
 
 hashMap *new_hashMap (void);
 void free_hashMap (hashMap *hash_map);
 
-void hash_extend (hashMap *hash_map);
-void hash_append (hashMap *hash_map, char *key, void *value, size_t value_size);
-void hash_pop (hashMap *hash_map);
-bool hash_search_index (hashMap *hash_map, char *key, void *return_index);
-bool hash_search (hashMap *hash_map, char *key, void *return_value);
-void hash_set (hashMap *hash_map, char *key, void *value, size_t value_size);
+void hash_extend       (hashMap *hash_map);
+void hash_append       (hashMap *hash_map, int32_t key, int32_t value);
+void hash_pop          (hashMap *hash_map);
+bool hash_search_index (hashMap *hash_map, int32_t key, uintmax_t *return_index);
+bool hash_search       (hashMap *hash_map, int32_t key, int32_t *return_value);
+void hash_set          (hashMap *hash_map, int32_t key, int32_t value);
 
 #endif

--- a/src/ws_program.c
+++ b/src/ws_program.c
@@ -276,50 +276,38 @@ wsError wsi_mod(wsProgram *program)
 wsError wsi_store(wsProgram *program)
 {
     wsInt value;
-    wsInt key_int;
-    char *key_string;
+    wsInt key;
 
     /* guard clauses */
     if (program->stack_index < 2)
         return WS_ERR_TOOFEWITEMS;
 
     /* get the key and value from the stack */
-    /* top item is key */
-    /* 2nd to top is value */
-    key_int = program->stack[program->stack_index - 2];
+    /* top item is value */
+    /* 2nd to top is key */
+    key   = program->stack[program->stack_index - 2];
     value = program->stack[program->stack_index - 1];
 
     /* take the top 2 items off the stack */
     program->stack_index -= 2;
 
-    /* allocate and convert int into key_string */
-    key_string = (char *)malloc((get_places(key_int, 10) + 1) * sizeof(char));
-    sprintf(key_string, "%d", key_int);
-
     /* add pair to the heap */
-    hash_set(program->heap, key_string, &value, sizeof(value));
+    hash_set(program->heap, key, value);
 
-    /* free the temporary key */
-    free(key_string);
     return WS_SUCCESS;
 }
 
 wsError wsi_restore(wsProgram *program)
 {
     wsInt value;
-    wsInt key_int;
-    char *key_string;
+    wsInt key;
     bool match_found;
 
     /* get the key from the stack */
-    key_int = program->stack[program->stack_index - 1];
-
-    /* allocate and convert int into key_string */
-    key_string = (char *)malloc((get_places(key_int, 10) + 1) * sizeof(char));
-    sprintf(key_string, "%d", key_int);
+    key = program->stack[program->stack_index - 1];
 
     /* look for a match */
-    match_found = hash_search(program->heap, key_string, &value);
+    match_found = hash_search(program->heap, key, &value);
 
     /* if no match is found return with error code */
     if (!match_found)
@@ -328,8 +316,6 @@ wsError wsi_restore(wsProgram *program)
     /* add item to stack */
     program->stack[program->stack_index - 1] = value;
 
-    /* free key_string */
-    free(key_string);
     return WS_SUCCESS;
 }
 
@@ -504,8 +490,7 @@ wsError wsi_puti(wsProgram *program)
 wsError wsi_readc(wsProgram *program)
 {
     char value;
-    int key_int;
-    char *key_str;
+    int key;
 
     /* check that there is atleast 1 element in the stack */
     /* top element of stack specifies where in the heap the input is to reside */
@@ -516,28 +501,22 @@ wsError wsi_readc(wsProgram *program)
     scanf("%c", &value);
 
     /* get key_int from top of stack */
-    key_int = program->stack[program->stack_index - 1];
+    key = program->stack[program->stack_index - 1];
 
     /* pop the top element off the stack */
     program->stack_index--;
 
-    /* allocate and convert int into key_string */
-    key_str = (char *)malloc((get_places(key_int, 10) + 1) * sizeof(char));
-    sprintf(key_str, "%d", key_int);
-
     /* add pair to the heap */
-    hash_set(program->heap, key_str, &value, sizeof(value));
+    hash_set(program->heap, key, value);
 
     /* exit gracefully */
-    free (key_str);
     return WS_SUCCESS;
 }
 
 wsError wsi_readi(wsProgram *program)
 {
     int value;
-    int key_int;
-    char *key_str;
+    int key;
 
     /* check that there is atleast 1 element in the stack */
     /* top element of stack specifies where in the heap the input is to reside */
@@ -548,20 +527,15 @@ wsError wsi_readi(wsProgram *program)
     scanf("%d", &value);
 
     /* get key_int from top of stack */
-    key_int = program->stack[program->stack_index - 1];
+    key = program->stack[program->stack_index - 1];
 
     /* pop the top element off the stack */
     program->stack_index--;
 
-    /* allocate and convert int into key_string */
-    key_str = (char *)malloc((get_places(key_int, 10) + 1) * sizeof(char));
-    sprintf(key_str, "%d", key_int);
-
     /* add pair to the heap */
-    hash_set(program->heap, key_str, &value, sizeof(value));
+    hash_set(program->heap, key, value);
 
     /* exit gracefully */
-    free (key_str);
     return WS_SUCCESS;
 }
 


### PR DESCRIPTION
hashtable module was made to work with many data types using string:generic however for this program we only need int:int so to save a fair bit of speed we converted it to int:int.

ws_heap based functions no longer have to convert key from int to string. and the hashtabel module now does int comparisons rather than strncmp. the hashtable module also no longer uses memcpy for value, now uses basic ints we can assign value to variables without the help of memcpy.