### PR TITLE
whitespace's runtime stack/heap now has full 64 bit integer support

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -4,21 +4,21 @@
     LeafWSI - a C based, cross-platform, whitespace lang interpretter.
     Copyright (C) 2023  Sage I. Hendricks
 
-    LeafWSI is free software: you can redistribute it and/or modify 
-    it under the terms of the GNU General Public License as published by 
-    the Free Software Foundation, either version 3 of the License, or 
+    LeafWSI is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
     (at your option) any later version.
 
-    LeafWSI is distributed in the hope that it will be useful, 
-    but WITHOUT ANY WARRANTY; without even the implied warranty of 
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the 
+    LeafWSI is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
     GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License 
-    along with LeafWSI. If not, see <https://www.gnu.org/licenses/>. 
+    You should have received a copy of the GNU General Public License
+    along with LeafWSI. If not, see <https://www.gnu.org/licenses/>.
 */
 
-/* 
+/*
 Contact Information:
     Email   sage.codes@email.com
     Github  sage-etcher
@@ -32,8 +32,13 @@ Contact Information:
 #ifndef _CONFIG_H_
 #define _CONFIG_H_
 
+#include <stdint.h>
+
 /* CONFIG.H START editting */
 /* edit bellow this point */
+
+/* typedefinition for default int size for whitespace script */
+typedef int64_t wsInt;
 
 /* how many elements can be in the stack */
 #define STACK_LEN 255

--- a/src/hashmap.c
+++ b/src/hashmap.c
@@ -34,10 +34,11 @@ Contact Information:
 #include <stdbool.h>
 #include <assert.h>
 
+#include "config.h"
 
 /* keyValuePair functions */
 /* create new keyValuePair */
-keyValuePair *new_keyValuePair (int32_t key, int32_t value)
+keyValuePair *new_keyValuePair (wsInt key, wsInt value)
 {
     keyValuePair *new_pair;
 
@@ -122,7 +123,7 @@ void hash_extend (hashMap *hash_map)
 }
 
 /* append a new item to the end of a hashmap*/
-void hash_append (hashMap *hash_map, int32_t key, int32_t value)
+void hash_append (hashMap *hash_map, wsInt key, wsInt value)
 {
     uintmax_t new_index = hash_map->count;
 
@@ -172,7 +173,7 @@ void hash_pop (hashMap *hash_map)
 
 /* search a hashMap for a specific key, and put the keyValuePair's index in a var */
 /* if a matching key is found, return true. otherwise, return false */
-bool hash_search_index (hashMap *hash_map, int32_t key, uintmax_t *return_index)
+bool hash_search_index (hashMap *hash_map, wsInt key, uintmax_t *return_index)
 {
     uintmax_t i = 0;
     keyValuePair *item;
@@ -211,7 +212,7 @@ bool hash_search_index (hashMap *hash_map, int32_t key, uintmax_t *return_index)
 
 /* search a hashMap for a specific key, and puts the key's value into a variable */
 /* if a matching key is found, return true. otherwise, return false */
-bool hash_search (hashMap *hash_map, int32_t key, int32_t *return_value)
+bool hash_search (hashMap *hash_map, wsInt key, wsInt *return_value)
 {
     uintmax_t match_index;
     keyValuePair *match;
@@ -238,7 +239,7 @@ bool hash_search (hashMap *hash_map, int32_t key, int32_t *return_value)
 
 
 /* set an element in the hashMap */
-void hash_set (hashMap *hash_map, int32_t key, int32_t value)
+void hash_set (hashMap *hash_map, wsInt key, wsInt value)
 {
     bool key_exists;
     uintmax_t key_index;

--- a/src/hashmap.h
+++ b/src/hashmap.h
@@ -39,6 +39,8 @@ Contact Information:
 #include <stdbool.h>
 #include <assert.h>
 
+#include "config.h"
+
 
 /* macros */
 #define HASHMAP_MAX(a,b) (a > b ? a : b)
@@ -48,8 +50,8 @@ Contact Information:
 /* type definitions */
 typedef struct
 {
-    int32_t key;
-    int32_t value;
+    wsInt key;
+    wsInt value;
 } keyValuePair;
 
 typedef struct
@@ -61,17 +63,17 @@ typedef struct
 
 
 /* function prototypes */
-keyValuePair *new_keyValuePair (int32_t key, int32_t value);
+keyValuePair *new_keyValuePair (wsInt key, wsInt value);
 void free_keyValuePair (keyValuePair *pair);
 
 hashMap *new_hashMap (void);
 void free_hashMap (hashMap *hash_map);
 
 void hash_extend       (hashMap *hash_map);
-void hash_append       (hashMap *hash_map, int32_t key, int32_t value);
+void hash_append       (hashMap *hash_map, wsInt key, wsInt value);
 void hash_pop          (hashMap *hash_map);
-bool hash_search_index (hashMap *hash_map, int32_t key, uintmax_t *return_index);
-bool hash_search       (hashMap *hash_map, int32_t key, int32_t *return_value);
-void hash_set          (hashMap *hash_map, int32_t key, int32_t value);
+bool hash_search_index (hashMap *hash_map, wsInt key, uintmax_t *return_index);
+bool hash_search       (hashMap *hash_map, wsInt key, wsInt *return_value);
+void hash_set          (hashMap *hash_map, wsInt key, wsInt value);
 
 #endif

--- a/src/ws_program.c
+++ b/src/ws_program.c
@@ -481,7 +481,7 @@ wsError wsi_puti(wsProgram *program)
     if (program->stack_index <= 0)
         return WS_ERR_TOOFEWITEMS;
 
-    printf("%d", program->stack[program->stack_index - 1]);
+    printf("%lld", program->stack[program->stack_index - 1]);
     program->stack_index--;
 
     return WS_SUCCESS;
@@ -490,7 +490,7 @@ wsError wsi_puti(wsProgram *program)
 wsError wsi_readc(wsProgram *program)
 {
     char value;
-    int key;
+    wsInt key;
 
     /* check that there is atleast 1 element in the stack */
     /* top element of stack specifies where in the heap the input is to reside */
@@ -515,8 +515,8 @@ wsError wsi_readc(wsProgram *program)
 
 wsError wsi_readi(wsProgram *program)
 {
-    int value;
-    int key;
+    wsInt value;
+    wsInt key;
 
     /* check that there is atleast 1 element in the stack */
     /* top element of stack specifies where in the heap the input is to reside */
@@ -524,7 +524,7 @@ wsError wsi_readi(wsProgram *program)
         return WS_ERR_TOOFEWITEMS;
 
     /* get input from stdin, and store it in a temporary variable */
-    scanf("%d", &value);
+    scanf("%lld", &value);
 
     /* get key_int from top of stack */
     key = program->stack[program->stack_index - 1];
@@ -548,7 +548,7 @@ wsError wsi_dprint(wsProgram *program)
     printf ("stack = [");
     for (; i < program->stack_index; i++)
     {
-        printf ("%d, ", program->stack[i]);
+        printf ("%lld, ", program->stack[i]);
     }
     printf ("]\n");
 

--- a/src/ws_program.h
+++ b/src/ws_program.h
@@ -81,8 +81,6 @@ typedef enum
     WS_INST_COUNT
 } WS_INST_INDEX;
 
-/* typedefinition for default int size for whitespace script */
-typedef int32_t wsInt;
 
 /* whitespace instruction container */
 typedef struct


### PR DESCRIPTION
updated console inputs, console outputs, hashmap, and wsInt to work with signed 64bit integers.
moved wsInt typedef into config.h
added config.h to hashmap module
updated hashmap module to use wsInt for both key and value